### PR TITLE
- Adjust disable-log-out gschema key usage for org.mate.lockdown change

### DIFF
--- a/main-menu/src/main-menu-ui.c
+++ b/main-menu/src/main-menu-ui.c
@@ -80,8 +80,6 @@
 #define MATE_LOCKDOWN_SCHEMA            "org.mate.lockdown"
 #define DISABLE_TERMINAL_SETTINGS_KEY   "disable-command-line"
 #define DISABLE_LOCKSCREEN_SETTINGS_KEY "disable-lock-screen"
-
-#define PANEL_SCHEMA                    "org.mate.panel"
 #define DISABLE_LOGOUT_SETTINGS_KEY     "disable-log-out"
 
 G_DEFINE_TYPE (MainMenuUI, main_menu_ui, G_TYPE_OBJECT)
@@ -335,7 +333,7 @@ main_menu_ui_new (MatePanelApplet *applet)
 	priv->filearea_settings = g_settings_new (FILE_AREA_SCHEMA);
 	priv->lockdown_settings = g_settings_new (LOCKDOWN_SETTINGS_SCHEMA);
 	priv->mate_lockdown_settings = g_settings_new (MATE_LOCKDOWN_SCHEMA);
-	priv->panel_settings = g_settings_new (PANEL_SCHEMA);
+	priv->panel_settings = g_settings_new (MATE_LOCKDOWN_SCHEMA);
 
 	window_ui_path = g_build_filename (DATADIR, PACKAGE, "slab-window.ui", NULL);
 	button_ui_path = g_build_filename (DATADIR, PACKAGE, "slab-button.ui", NULL);


### PR DESCRIPTION
By commit d16d491d2fbe94e3c0711c9b5282734e0f26d33f to the mate-panel; disable-log-out key moved to mate-lockdown gschema thus gnome-main-menu needs to know where this key is. This commit modifies main-menu/scr/main-menu-ui to reflect this change. If it is used with monsta's https://github.com/GNOME/gnome-main-menu/pull/2 request we can have a working gnome-main-menu with Mate 1.9.x
