### PR TITLE
- Help button opens mate-user-guide fix

### DIFF
--- a/main-menu/etc/system-items.xbel.in
+++ b/main-menu/etc/system-items.xbel.in
@@ -3,7 +3,7 @@
       xmlns:bookmark="http://www.freedesktop.org/standards/desktop-bookmarks"
       xmlns:mime="http://www.freedesktop.org/standards/shared-mime-info"
 >
-  <bookmark href="yelp.desktop" added="2007-01-16T05:53:36Z" modified="2007-01-16T05:53:36Z" visited="2007-01-16T05:53:36Z">
+  <bookmark href="mate-user-guide.desktop" added="2007-01-16T05:53:36Z" modified="2007-01-16T05:53:36Z" visited="2007-01-16T05:53:36Z">
     <_title>Help</_title>
     <info>
       <metadata owner="http://freedesktop.org">
@@ -12,7 +12,7 @@
           <bookmark:group>rank-0</bookmark:group>
         </bookmark:groups>
         <bookmark:applications>
-          <bookmark:application name="Yelp" exec="yelp" timestamp="1168926816" count="1"/>
+          <bookmark:application name="Yelp" exec="yelp help:mate-user-guide" timestamp="1168926816" count="1"/>
         </bookmark:applications>
       </metadata>
     </info>


### PR DESCRIPTION
Help button currently opens a blank yelp page. This commit makes "Help" button to open mate-user-guide; if installed.
